### PR TITLE
haskell-flake: modular overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1684876793,
-        "narHash": "sha256-4aBnYmtXjvZXl+K2oYSUHT441Bz+b+vumARUETrzP6Y=",
+        "lastModified": 1685470074,
+        "narHash": "sha256-0vdewKY4Vmx476Qg5qd2voyuL7ZssqOUlQeNJCuvs3Q=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "4b5d6be277db5d11320d153f7fd17ab3cab4fab5",
+        "rev": "9b0393630068e688795bedd46c49df1a0bbc7c0a",
         "type": "github"
       },
       "original": {
@@ -256,16 +256,15 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1684780604,
-        "narHash": "sha256-2uMZsewmRn7rRtAnnQNw1lj0uZBMh4m6Cs/7dV5YF08=",
+        "lastModified": 1685469326,
+        "narHash": "sha256-esxJLsGexI/J6Fc32tJd2p3K5IOBZSCHgFvegjIpc+0=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "74210fa80a49f1b6f67223debdbf1494596ff9f2",
+        "rev": "996f5c2cdc67285c4990df378976f9dbf26f8401",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "0.3.0",
         "repo": "haskell-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           inputsFrom = [
             config.haskellProjects.default.outputs.devShell
             config.pre-commit.devShell
+            config.flake-root.devShell
           ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     inputs.common.lib.mkFlake { inherit inputs; } {
       perSystem = { self', pkgs, lib, config, ... }: {
         haskellProjects.default = {
+          projectFlakeName = "clickhouse-haskell";
           autoWire = [ "packages" "checks" ];
         };
         packages.default = self'.packages.clickhouse-haskell;


### PR DESCRIPTION
Update haskell-flake to use [srid/haskell-flake#162](https://github.com/srid/haskell-flake/pull/162) which gets us

- a nicer API for overriding Haskell packages.
- reduced duplicate builds (due to use `build-haskell-package.nix` for dependencies and local packages alike.
- add default overrides for all local packages. This should also reduce build times across repos by reusing the same package from dependency builds.